### PR TITLE
Fix lint failures blocking Next.js build

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { EmailMessage, EmailAccount } from '@/types/email';
 import { Mail, Send, RefreshCw, Settings, Plus } from 'lucide-react';
 import EmailList from '@/components/EmailList';
@@ -18,26 +18,9 @@ export default function Home() {
   const [emailAccount, setEmailAccount] = useState<EmailAccount | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Check if user has saved email configuration on component mount
-  useEffect(() => {
-    const savedConfig = localStorage.getItem('emailAccount');
-    if (savedConfig) {
-      try {
-        const account = JSON.parse(savedConfig);
-        setEmailAccount(account);
-        setIsConfigured(true);
-        // Auto-fetch emails on startup
-        fetchEmails(account);
-      } catch (error) {
-        console.error('Failed to parse saved email config:', error);
-        localStorage.removeItem('emailAccount');
-      }
-    }
-  }, []);
-
-  const fetchEmails = async (account?: EmailAccount) => {
+  const fetchEmails = useCallback(async (account?: EmailAccount) => {
     if (!account && !emailAccount) return;
-    
+
     const currentAccount = account || emailAccount;
     if (!currentAccount) return; // Additional null check for TypeScript strict mode
     
@@ -69,7 +52,24 @@ export default function Home() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [emailAccount]);
+
+  // Check if user has saved email configuration on component mount
+  useEffect(() => {
+    const savedConfig = localStorage.getItem('emailAccount');
+    if (savedConfig) {
+      try {
+        const account = JSON.parse(savedConfig);
+        setEmailAccount(account);
+        setIsConfigured(true);
+        // Auto-fetch emails on startup
+        fetchEmails(account);
+      } catch (error) {
+        console.error('Failed to parse saved email config:', error);
+        localStorage.removeItem('emailAccount');
+      }
+    }
+  }, [fetchEmails]);
 
   const handleRefresh = async () => {
     await fetchEmails();

--- a/src/components/EmailConfigModal.tsx
+++ b/src/components/EmailConfigModal.tsx
@@ -142,7 +142,7 @@ export default function EmailConfigModal({ onClose, onSave }: EmailConfigModalPr
             </div>
             {formData.provider === 'gmail' && (
               <p className="mt-1 text-xs text-gray-500">
-                For Gmail, you'll need to use an App Password. Enable 2FA and generate an App Password in your Google Account settings.
+                For Gmail, you must use an App Password. Enable 2FA and generate an App Password in your Google Account settings.
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add the standard Next.js ESLint configuration so `npm run lint` can run non-interactively
- wrap the email fetch helper in `useCallback` and reference it from the initialization effect to satisfy React hook linting
- rephrase the Gmail helper copy to avoid the `react/no-unescaped-entities` warning

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10c5e0fc483319d28cf0e1c635976