### PR TITLE
Secure IMAP TLS defaults and add verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ You can add custom SMTP/IMAP servers by modifying the `EMAIL_PROVIDERS` configur
 - **Production**: Consider implementing proper authentication and encrypted credential storage
 - **Gmail**: Always use App Passwords, never your main password
 - **Network**: All email connections use TLS/SSL encryption
+- **TLS Verification**: IMAP connections require valid certificates. To enable self-signed certificates for debugging (non-production only), set `IMAP_ALLOW_SELF_SIGNED=true` in your environment.
+
+## Manual TLS Verification
+
+Verify that TLS negotiation works against providers with trusted certificates using the included script:
+
+```bash
+npm run verify:imap-tls
+```
+
+By default this checks `imap.gmail.com:993`. You can override the target with environment variables:
+
+```bash
+IMAP_VERIFY_HOST=outlook.office365.com IMAP_VERIFY_PORT=993 npm run verify:imap-tls
+```
+
+The command connects using Node's default certificate store and fails if the certificate chain is not trusted, confirming the application no longer bypasses TLS verification.
 
 ## File Structure
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "verify:imap-tls": "node scripts/verify-imap-tls.mjs"
   },
   "dependencies": {
     "@types/dompurify": "^3.0.5",

--- a/scripts/verify-imap-tls.mjs
+++ b/scripts/verify-imap-tls.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import tls from 'node:tls';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const host = process.env.IMAP_VERIFY_HOST || 'imap.gmail.com';
+const port = Number(process.env.IMAP_VERIFY_PORT || 993);
+const timeoutMs = Number(process.env.IMAP_VERIFY_TIMEOUT || 10000);
+
+const socket = tls.connect({
+  host,
+  port,
+  servername: host,
+  rejectUnauthorized: true,
+});
+
+let completed = false;
+
+const handleFailure = (error) => {
+  if (completed) return;
+  completed = true;
+  console.error('❌ TLS verification failed:', error);
+  socket.destroy();
+
+  if (error && typeof error === 'object' && 'code' in error && error.code === 'ENETUNREACH') {
+    console.error('Network is unreachable. Ensure outbound IMAP access is allowed in your environment.');
+  }
+
+  process.exit(1);
+};
+
+socket.once('secureConnect', () => {
+  if (completed) return;
+  completed = true;
+
+  if (!socket.authorized) {
+    handleFailure(socket.authorizationError || 'Certificate not authorized');
+    return;
+  }
+
+  console.log(
+    `✅ Successfully negotiated TLS with ${host}:${port}.`,
+    socket.getProtocol() ? `Protocol: ${socket.getProtocol()}` : ''
+  );
+  socket.end();
+  process.exit(0);
+});
+
+socket.once('error', handleFailure);
+
+await delay(timeoutMs).then(() => {
+  if (!completed) {
+    handleFailure(new Error(`Timed out after ${timeoutMs}ms while waiting for TLS handshake.`));
+  }
+});

--- a/src/app/api/email/fetch/route.ts
+++ b/src/app/api/email/fetch/route.ts
@@ -58,16 +58,24 @@ function getFirstEmailAddress(addressObj: any): string {
   return String(firstAddress);
 }
 
+const allowSelfSignedTls =
+  process.env.NODE_ENV !== 'production' && process.env.IMAP_ALLOW_SELF_SIGNED === 'true';
+
 function connectToIMAP(config: IMAPConfig): Promise<Imap> {
   return new Promise((resolve, reject) => {
-    const imap = new Imap({
+    const imapOptions: Imap.Config = {
       user: config.auth.user,
       password: config.auth.pass,
       host: config.host,
       port: config.port,
       tls: config.tls,
-      tlsOptions: { rejectUnauthorized: false },
-    });
+    };
+
+    if (allowSelfSignedTls) {
+      imapOptions.tlsOptions = { rejectUnauthorized: false };
+    }
+
+    const imap = new Imap(imapOptions);
 
     imap.once('ready', () => resolve(imap));
     imap.once('error', (err: Error) => reject(err));

--- a/src/app/api/email/test/route.ts
+++ b/src/app/api/email/test/route.ts
@@ -23,16 +23,24 @@ async function testSMTPConnection(config: SMTPConfig): Promise<boolean> {
   }
 }
 
+const allowSelfSignedTls =
+  process.env.NODE_ENV !== 'production' && process.env.IMAP_ALLOW_SELF_SIGNED === 'true';
+
 async function testIMAPConnection(config: IMAPConfig): Promise<boolean> {
   return new Promise((resolve) => {
-    const imap = new Imap({
+    const imapOptions: Imap.Config = {
       user: config.auth.user,
       password: config.auth.pass,
       host: config.host,
       port: config.port,
       tls: config.tls,
-      tlsOptions: { rejectUnauthorized: false },
-    });
+    };
+
+    if (allowSelfSignedTls) {
+      imapOptions.tlsOptions = { rejectUnauthorized: false };
+    }
+
+    const imap = new Imap(imapOptions);
 
     let resolved = false;
 


### PR DESCRIPTION
## Summary
- require valid certificates by default when creating IMAP clients in the fetch and test API routes, with an opt-in debug flag for self-signed servers
- document the new IMAP_ALLOW_SELF_SIGNED escape hatch and add a manual TLS verification guide
- add a verify-imap-tls helper script and npm task to confirm trusted providers negotiate TLS successfully

## Testing
- npm run verify:imap-tls *(fails in container: ENETUNREACH outbound IMAP blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d10d6cd36883319e387875eeb23722